### PR TITLE
Fix for channel_not_found error when doing bot reply of an interactive message request

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -28,7 +28,7 @@ class Bot {
       else console.error("Can't send a private message without a response_url");
     }
     else if (channel_id || channel) {
-      if (channel) channel_id = channel;
+      if (channel) channel_id = channel.id;
       message.channel = channel_id;
       return this.send(message);
     }


### PR DESCRIPTION
Doing a bot.reply() on an interactive_message event failed with error `channel_not_found`.

```
slack.on("interactive_message", (payload, bot) => {
  bot.reply("Boy says hello!");
});
```

This happened because the line https://github.com/johnagan/express-slack/compare/master...stpe:master#diff-09b0d1ce42aaadb6154c5e9b97d4c743L31 assigned `channel` as `channel_id`. However, `channel` is an object with properties `id` and `name` while `channel_id` must only be the actual id.