### PR TITLE
Fix token verification in interactive message button callback

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -61,6 +61,9 @@ class Controller extends EventEmitter {
     let {body} = req
     let {token} = this.settings
 
+    // message buttons
+    if (body.payload) body = JSON.parse(body.payload);
+
     if (!token || token === body.token) {
       this.emit('url_verification', true, req.body);
       next();


### PR DESCRIPTION
When the user clicks a button on an interactive message a HTTP POST is made with a JSON body with only one property; `payload` which is a `application/x-www-form-urlencoded`JSON string. In order to perform token verification the payload must be parsed to access the token property.

It looks like this change in the recent version broke this:
https://github.com/johnagan/express-slack/commit/06bdcfcd4941b6ec50cebf2a0daba0a70d222041#diff-9239b3dffffe6a441e7d599c0b66e5cfL65

...causing interactive message button callbacks to always fail with 401.

This PR readds this and fixes verification.